### PR TITLE
Update lab7-CF.yml to use Lambda Python 3.9

### DIFF
--- a/code/lab7/template/lab7-CF.yml
+++ b/code/lab7/template/lab7-CF.yml
@@ -49,7 +49,7 @@ Resources:
             Fn::GetAtt:
               - TextractProcessingRole
               - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 600
       CodeUri: s3://aws-ml-blog/artifacts/textract-paragraph-blog/textract-blog-source-code.zip
   TextractPostProcessLambda:
@@ -61,7 +61,7 @@ Resources:
       Role: !GetAtt
         - TextractProcessingRole
         - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 600
       CodeUri: s3://aws-ml-blog/artifacts/textract-paragraph-blog/textract-blog-source-code.zip
   SNS:


### PR DESCRIPTION
3.6 is no longer supported. CF will fail with an error.

*Issue #, if available:*

CF breaks

*Description of changes:*

Updating Python version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
